### PR TITLE
Missing /cgi-bin/luci/rpc/auth support in nginx

### DIFF
--- a/devices/common/patches/nginx_luci.patch
+++ b/devices/common/patches/nginx_luci.patch
@@ -10,7 +10,7 @@
  		uwsgi_pass unix:////var/run/luci-webui.socket;
  }
 -location ~ /cgi-bin/cgi-(backup|download|upload|exec) {
-+location ~ /cgi-(backup|download|upload|exec) {
++location ~ /cgi-(backup|download|upload|exec|bin) {
  		include uwsgi_params;
 +		uwsgi_read_timeout 300s;
  		uwsgi_param SERVER_ADDR $server_addr;


### PR DESCRIPTION
Hi guy,

I found it error in the nginx file /etc/nginx/conf.d/luci.locations which is missing to support some url like http://ip/cgi-bin/luci/rpc/auth.

So the patch file maybe need to be updated.